### PR TITLE
Giphy block work around

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,6 +12,8 @@ var rmdir = require('rimraf');
 var htmlEncode = require('htmlencode').htmlEncode;
 var request = require('request');
 
+var giphyReserve = [];
+
 function save(msg, encode) {
 	var messages = JSON.parse(fs.readFileSync('data.json'));
 	msg = JSON.parse(msg);
@@ -152,11 +154,13 @@ io.on('connection', function(ws) {
 					var gif = Math.floor(Math.random() * data.data.length);
 					var embedLink = data.data[gif].images.fixed_width;
 					var i = 0;
-					while(fs.existsSync('uploads/giphy/' + i + '.gif')) {
+					while(fs.existsSync('uploads/giphy/' + i + '.gif') || giphyReserve.indexOf(i) > -1) {
 						i++;
 					}
+					giphyReserve.push(i);
 					var stream = request(embedLink.url).pipe(fs.createWriteStream('uploads/giphy/' + i + '.gif'));
 					stream.on('finish', function() {
+						giphyReserve.splice(giphyReserve.indexOf(i), 1);
 						msg.path = 'uploads/giphy/' + i + '.gif';
 						msg.data = '<img src="' + 'giphy/' + i + '.gif' + '" width="' + embedLink.width + '" height="' + embedLink.height + '">';
 						msg = JSON.stringify(msg);

--- a/server.js
+++ b/server.js
@@ -46,7 +46,7 @@ if(!fs.existsSync('uploads/giphy')) {
 	fs.mkdirSync('uploads/giphy');
 }
 
-io.emit('update', fs.readFileSync('data.json').toString());
+//io.emit('update', fs.readFileSync('data.json').toString());
 
 app.use(express.static('public'));
 
@@ -106,7 +106,7 @@ app.post('/image-upload', upload.single('image'), function(req, res) {
 		//fs.writeFileSync('uploads/' + name, data);
 		fs.writeFileSync('uploads/chat-images/' + name, data);
 		fs.unlinkSync(path);
-		var msg = JSON.stringify({name: req.body.name, data: '<img src="chat-images/' + name + '">', path: 'uploads/chat-images/' + name});
+		var msg = JSON.stringify({name: req.body.name, data: '<img src="chat-images/' + name + '?stamp=' + Date.now() + '">', path: 'uploads/chat-images/' + name});
 		save(msg, true);
 		res.send('<html><script>localStorage.close = "true"</script></html>');
 	});

--- a/server.js
+++ b/server.js
@@ -42,7 +42,7 @@ if(!fs.existsSync('uploads/chat-images')) {
 	fs.mkdirSync('uploads/chat-images');
 }
 
-if(!fs.existsSync('public/giphy')) {
+if(!fs.existsSync('uploads/giphy')) {
 	fs.mkdirSync('uploads/giphy');
 }
 
@@ -162,7 +162,7 @@ io.on('connection', function(ws) {
 					stream.on('finish', function() {
 						giphyReserve.splice(giphyReserve.indexOf(i), 1);
 						msg.path = 'uploads/giphy/' + i + '.gif';
-						msg.data = '<img src="' + 'giphy/' + i + '.gif' + '" width="' + embedLink.width + '" height="' + embedLink.height + '">';
+						msg.data = '<img src="' + 'giphy/' + i + '.gif?stamp=' + Date.now() + '" width="' + embedLink.width + '" height="' + embedLink.height + '">';
 						msg = JSON.stringify(msg);
 						save(msg, true);
 					});


### PR DESCRIPTION
Instead of making the client fetch the gif, the server will download it, and the client will fetch it from the server. I did this because giphy may be commonly blocked for bad content, but NITE limits it to a rating of G.
